### PR TITLE
Update GitHub URLs for model weights to v2.0.0

### DIFF
--- a/starling/configs.py
+++ b/starling/configs.py
@@ -80,9 +80,9 @@ DEFAULT_DDPM_WEIGHTS_PATH = fix_ref_to_home(
 
 # Github Releases URLs for model weights
 GITHUB_ENCODER_URL = (
-    "https://github.com/idptools/starling/releases/download/v2.0.0-alpha/vae.ckpt"
+    "https://github.com/idptools/starling/releases/download/v2.0.0/STARLING_v2.0.0_ViT_VAE_2025_10_14.ckpt"
 )
-GITHUB_DDPM_URL = "https://github.com/idptools/starling/releases/download/v2.0.0-alpha/diffusion_model.ckpt"
+GITHUB_DDPM_URL = "https://github.com/idptools/starling/releases/download/v2.0.0/STARLING_v2.0.0_ViT_DDPM_2025_10_14.ckpt"
 
 # Update default paths to check Hub first
 DEFAULT_ENCODER_WEIGHTS_PATH = os.environ.get(


### PR DESCRIPTION
fixed 'HTTP Error 404: Not Found' (Issue 8). previous URL tries to download something that doesn't exists. Probably something changed with recent releases.
